### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and Accounts.framework, MessageUI.framework. SocialEngine is for iOS version 6.0
 
 ## Requirements
 * iOS 6.x and higher.
-* XCode 6.0 or later
+* Xcode 6.0 or later
 * Social.framework
 * Twitter.framework
 * Accounts.framework


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
